### PR TITLE
feat: chain groups

### DIFF
--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stakekit/rainbowkit",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "The best way to connect a wallet",
   "files": ["dist", "styles.css", "wallets"],
   "type": "module",

--- a/packages/rainbowkit/src/index.ts
+++ b/packages/rainbowkit/src/index.ts
@@ -21,6 +21,7 @@ export type {
   WalletList,
   WalletDetailsParams,
   RainbowKitWalletConnectParameters,
+  ChainGroup,
 } from './wallets/Wallet';
 export type { Theme } from './components/RainbowKitProvider/RainbowKitProvider';
 export type {

--- a/packages/rainbowkit/src/locales/en_US.json
+++ b/packages/rainbowkit/src/locales/en_US.json
@@ -46,6 +46,9 @@
   "connect": {
     "label": "Connect",
     "title": "Connect a Wallet",
+    "select_chain_group": {
+      "title": "Select a Chain"
+    },
     "new_to_ethereum": {
       "description": "New to Ethereum wallets?",
       "learn_more": {
@@ -194,6 +197,8 @@
 
   "chains": {
     "title": "Switch Networks",
+    "select_title": "Select Network",
+    "select_group": "Select Chain Group",
     "wrong_network": "Wrong network detected, switch or disconnect to continue.",
     "confirm": "Confirm in Wallet",
     "confirm_error": "Error switching chain",

--- a/packages/rainbowkit/src/utils/chain-groups.ts
+++ b/packages/rainbowkit/src/utils/chain-groups.ts
@@ -1,0 +1,7 @@
+import type { ChainGroup } from '../wallets/Wallet';
+
+export const ethereumChainGroup: ChainGroup = {
+  id: 'ethereum',
+  title: 'Ethereum',
+  iconUrl: 'https://assets.stakek.it/networks/ethereum.svg',
+};

--- a/packages/rainbowkit/src/wallets/Wallet.ts
+++ b/packages/rainbowkit/src/wallets/Wallet.ts
@@ -75,6 +75,7 @@ export type Wallet = {
   };
   hidden?: () => boolean;
   createConnector: (walletDetails: WalletDetailsParams) => CreateConnectorFn;
+  chainGroup: ChainGroup;
 } & RainbowKitConnector;
 
 export interface DefaultWalletOptions {
@@ -113,7 +114,14 @@ export type RainbowKitDetails = Omit<Wallet, 'createConnector' | 'hidden'> & {
   // Used specifically in `connectorsForWallets` logic
   // to make sure we can also get WalletConnect modal in rainbowkit
   showQrModal?: true;
+  chainGroup: ChainGroup;
 };
+
+export interface ChainGroup {
+  id: 'ethereum' | (string & {});
+  title: string;
+  iconUrl: string;
+}
 
 export type WalletDetailsParams = { rkDetails: RainbowKitDetails };
 

--- a/packages/rainbowkit/src/wallets/walletConnectors/ZilPayWallet/zilPayWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ZilPayWallet/zilPayWallet.ts
@@ -1,4 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -20,6 +21,7 @@ export const zilPayWallet = ({
     rdns: 'io.zilpay',
     iconUrl: async () => (await import('./zilPayWallet.svg')).default,
     iconBackground: '#ffffff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=com.zilpaymobile',
       ios: 'https://apps.apple.com/ru/app/zilpay/id1547105860',

--- a/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
@@ -26,6 +27,7 @@ export const argentWallet = ({
         : `argent://app/wc?uri=${encodeURIComponent(uri)}`;
     },
   },
+  chainGroup: ethereumChainGroup,
   qrCode: {
     getUri: (uri: string) => uri,
     instructions: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/backpackWallet/backpackWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/backpackWallet/backpackWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -12,6 +13,7 @@ export const backpackWallet = (): Wallet => {
     iconUrl: async () => (await import('./backpackWallet.svg')).default,
     iconBackground: '#0C0D10',
     installed: hasInjectedProvider({ namespace: 'backpack.ethereum' }),
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=app.backpack.mobile',

--- a/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -23,6 +24,7 @@ export const berasigWallet = ({
     iconUrl: async () => (await import('./berasigWallet.svg')).default,
     iconBackground: '#ffffff',
     installed: isBerasigWalletInjected,
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=io.berasig.ios',
       ios: 'https://apps.apple.com/us/app/berasig-wallet-on-berachain/id6502052535',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bestWallet/bestWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bestWallet/bestWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { DefaultWalletOptions } from './../../Wallet';
@@ -12,6 +13,7 @@ export const bestWallet = ({
   name: 'Best Wallet',
   iconUrl: async () => (await import('./bestWallet.svg')).default,
   iconBackground: '#5961FF',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     android: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
     ios: 'https://best.sng.link/Dnio2/rto7?_smtype=3',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { Wallet } from '../../Wallet';
 import {
@@ -30,6 +31,7 @@ export const bifrostWallet = ({
     iconUrl: async () => (await import('./bifrostWallet.svg')).default,
     iconBackground: '#fff',
     installed: !shouldUseWalletConnect ? isBifrostInjected : undefined,
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.bifrostwallet.app',

--- a/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
@@ -24,6 +25,7 @@ export const binanceWallet = ({
     iconUrl: async () => (await import('./binanceWallet.svg')).default,
     iconBackground: '#000000',
     installed: !shouldUseWalletConnect ? isBinanceInjected : undefined,
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=com.binance.dev',
       ios: 'https://apps.apple.com/us/app/id1436799971',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
@@ -26,6 +27,7 @@ export const bitgetWallet = ({
     iconAccent: '#f6851a',
     iconBackground: '#fff',
     installed: !shouldUseWalletConnect ? isBitKeepInjected : undefined,
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android: 'https://web3.bitget.com/en/wallet-download?type=0',
       ios: 'https://apps.apple.com/app/bitkeep/id1395301115',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -10,6 +11,7 @@ export const bitskiWallet = (): Wallet => ({
   installed: hasInjectedProvider({ flag: 'isBitski' }),
   iconUrl: async () => (await import('./bitskiWallet.svg')).default,
   iconBackground: '#fff',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     chrome:
       'https://chrome.google.com/webstore/detail/bitski/feejiigddaafeojfddjjlmfkabimkell',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitverseWallet/bitverseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitverseWallet/bitverseWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -11,6 +12,7 @@ export const bitverseWallet = ({
   name: 'Bitverse Wallet',
   iconUrl: async () => (await import('./bitverseWallet.svg')).default,
   iconBackground: '#171728',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     android:
       'https://play.google.com/store/apps/details?id=com.bitverse.app&pli=1',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bloomWallet/bloomWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bloomWallet/bloomWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -10,6 +11,7 @@ export const bloomWallet = ({
   iconBackground: '#000',
   iconAccent: '#000',
   iconUrl: async () => (await import('./bloomWallet.svg')).default,
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     desktop: 'https://bloomwallet.io/',
   },

--- a/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -11,6 +12,7 @@ export const braveWallet = (): Wallet => ({
   iconUrl: async () => (await import('./braveWallet.svg')).default,
   iconBackground: '#fff',
   installed: hasInjectedProvider({ flag: 'isBraveWallet' }),
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     // We're opting not to provide a download prompt if Brave isn't the current
     // browser since it's unlikely to be a desired behavior for users. It's

--- a/packages/rainbowkit/src/wallets/walletConnectors/bybitWallet/bybitWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bybitWallet/bybitWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -30,6 +31,7 @@ export const bybitWallet = ({
     iconUrl: async () => (await import('./bybitWallet.svg')).default,
     installed: !shouldUseWalletConnect ? isBybitInjected : undefined,
     iconBackground: '#000000',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/bybit-wallet/pdliaogehgdbhbnmkklieghmmjkpigpa',

--- a/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -21,6 +22,7 @@ export const clvWallet = ({
     iconBackground: '#fff',
     iconAccent: '#BDFDE2',
     installed: isCLVInjected,
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       chrome:
         'https://chrome.google.com/webstore/detail/clv-wallet/nhnkbkgjikgcigadomkphalanndcapjk',

--- a/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -25,6 +26,7 @@ export const coin98Wallet = ({
     iconAccent: '#CDA349',
     iconBackground: '#fff',
     rdns: 'coin98.com',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=coin98.crypto.finance.media',

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { type CreateConnectorFn, createConnector } from 'wagmi';
 import {
   type CoinbaseWalletParameters,
@@ -37,6 +38,7 @@ export const coinbaseWallet: CoinbaseWallet = ({ appName, appIcon }) => {
     // prompting the user to connect or create a wallet via passkey. This means if you either have
     // or don't have the coinbase wallet browser extension installed it'll do some action anyways
     installed: true,
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=org.toshi',
       ios: 'https://apps.apple.com/us/app/coinbase-wallet-store-crypto/id1278383455',

--- a/packages/rainbowkit/src/wallets/walletConnectors/compassWallet/compassWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/compassWallet/compassWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -14,6 +15,7 @@ export const compassWallet = (): Wallet => {
     rdns: 'io.leapwallet.CompassWallet',
     iconUrl: async () => (await import('./compassWallet.svg')).default,
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/compass-wallet-for-sei/anokgmphncpekkhclmingpimjmcooifb',

--- a/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -23,6 +24,7 @@ export const coreWallet = ({
     iconUrl: async () => (await import('./coreWallet.svg')).default,
     iconBackground: '#1A1A1C',
     installed: !shouldUseWalletConnect ? isCoreInjected : undefined,
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=com.avaxwallet',
       ios: 'https://apps.apple.com/us/app/core-wallet/id6443685999',

--- a/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { isIOS } from '../../../utils/isMobile';
 import type { Wallet } from '../../Wallet';
 import {
@@ -12,6 +13,7 @@ export const dawnWallet = (): Wallet => ({
   iconBackground: '#000000',
   installed: hasInjectedProvider({ flag: 'isDawn' }),
   hidden: () => !isIOS(),
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/us/app/dawn-ethereum-wallet/id1673143782',
     mobile: 'https://dawnwallet.xyz',

--- a/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -11,6 +12,7 @@ export const desigWallet = (): Wallet => {
     iconUrl: async () => (await import('./desigWallet.svg')).default,
     iconBackground: '#ffffff',
     installed: hasInjectedProvider({ namespace: 'desig.ethereum' }),
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=io.desig.app',
       ios: 'https://apps.apple.com/app/desig-wallet/id6450106028',

--- a/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -12,6 +13,7 @@ export const enkryptWallet = (): Wallet => {
     installed: hasInjectedProvider({ namespace: 'enkrypt.providers.ethereum' }),
     iconUrl: async () => (await import('./enkryptWallet.svg')).default,
     iconBackground: '#FFFFFF',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       qrCode: 'https://www.enkrypt.com',
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -21,6 +22,7 @@ export const foxWallet = ({
     name: 'FoxWallet',
     iconUrl: async () => (await import('./foxWallet.svg')).default,
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.foxwallet.play',

--- a/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -11,6 +12,7 @@ export const frameWallet = (): Wallet => ({
   installed: hasInjectedProvider({ flag: 'isFrame' }),
   iconUrl: async () => (await import('./frameWallet.svg')).default,
   iconBackground: '#121C20',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     browserExtension: 'https://frame.sh/',
   },

--- a/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { Wallet } from '../../Wallet';
 import {
@@ -25,6 +26,7 @@ export const frontierWallet = ({
     installed: isFrontierInjected,
     iconUrl: async () => (await import('./frontierWallet.svg')).default,
     iconBackground: '#CC703C',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.frontierwallet',

--- a/packages/rainbowkit/src/wallets/walletConnectors/gateWallet/gateWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/gateWallet/gateWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
@@ -22,6 +23,7 @@ export const gateWallet = ({
     iconUrl: async () => (await import('./gateWallet.svg')).default,
     iconAccent: '#fff',
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.gateio.gateio',

--- a/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -11,6 +12,7 @@ export const imTokenWallet = ({
   name: 'imToken',
   iconUrl: async () => (await import('./imTokenWallet.svg')).default,
   iconBackground: '#098de6',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     android: 'https://play.google.com/store/apps/details?id=im.token.app',
     ios: 'https://itunes.apple.com/us/app/imtoken2/id1384798940',

--- a/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import { getInjectedConnector } from '../../getInjectedConnector';
 
@@ -6,5 +7,6 @@ export const injectedWallet = (): Wallet => ({
   name: 'Browser Wallet',
   iconUrl: async () => (await import('./injectedWallet.svg')).default,
   iconBackground: '#fff',
+  chainGroup: ethereumChainGroup,
   createConnector: getInjectedConnector({}),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/iopayWallet/iopayWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/iopayWallet/iopayWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getInjectedConnector } from '../../getInjectedConnector';
@@ -22,6 +23,7 @@ export const iopayWallet = ({
   name: 'ioPay Wallet',
   iconUrl: async () => (await import('./iopayWallet.svg')).default,
   iconBackground: '#fff',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     android:
       'https://play.google.com/store/apps/details?id=io.iotex.iopay.gp&pli=1',

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaiaWallet/kaiaWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaiaWallet/kaiaWallet.ts
@@ -1,4 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -27,6 +28,7 @@ export const kaiaWallet = ({
     iconUrl: async () => (await import('./kaiaWallet.svg')).default,
     installed: isKaiaWalletInjected || undefined,
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/kaia-wallet/jblndlipeogpafnldhgmapagcccfchpi',

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
@@ -1,4 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -27,6 +28,7 @@ export const kaikasWallet = ({
     iconUrl: async () => (await import('./kaikasWallet.svg')).default,
     installed: isKaikasWalletInjected || undefined,
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/kaikas/jblndlipeogpafnldhgmapagcccfchpi',

--- a/packages/rainbowkit/src/wallets/walletConnectors/krakenWallet/krakenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/krakenWallet/krakenWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { DefaultWalletOptions } from './../../Wallet';
 
@@ -12,6 +13,7 @@ export const krakenWallet = ({
   name: 'Kraken Wallet',
   iconUrl: async () => (await import('./krakenWallet.svg')).default,
   iconBackground: '#FFD8EA',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/us/app/kraken-wallet/id1626327149',
     mobile: 'https://kraken.com/wallet',

--- a/packages/rainbowkit/src/wallets/walletConnectors/kresusWallet/kresusWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kresusWallet/kresusWallet.ts
@@ -1,4 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export type KresusWalletOptions = DefaultWalletOptions;
@@ -11,6 +12,7 @@ export const kresusWallet = ({
   name: 'Kresus Wallet',
   iconUrl: async () => (await import('./kresusWallet.svg')).default,
   iconBackground: '#fff',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     android:
       'https://play.google.com/store/apps/details?id=com.kresus.superapp',

--- a/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
@@ -1,4 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -10,6 +11,7 @@ export const ledgerWallet = ({
 }: LedgerWalletOptions): Wallet => ({
   id: 'ledger',
   iconBackground: '#000',
+  chainGroup: ethereumChainGroup,
   iconAccent: '#000',
   name: 'Ledger',
   iconUrl: async () => (await import('./ledgerWallet.svg')).default,

--- a/packages/rainbowkit/src/wallets/walletConnectors/magicEdenWallet/magicEdenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/magicEdenWallet/magicEdenWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -11,6 +12,7 @@ export const magicEdenWallet = (): Wallet => {
     rdns: 'io.magiceden.wallet',
     iconUrl: async () => (await import('./magicEden.svg')).default,
     iconBackground: '#36114D',
+    chainGroup: ethereumChainGroup,
     installed: hasInjectedProvider({ namespace: 'magicEden.ethereum' }),
     downloadUrls: {
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -1,4 +1,5 @@
 import { createConnector } from 'wagmi';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { metaMask } from 'wagmi/connectors';
 import type {
   DefaultWalletOptions,
@@ -82,6 +83,7 @@ export const metaMaskWallet = ({
     iconUrl: async () => (await import('./metaMaskWallet.svg')).default,
     iconAccent: '#f6851a',
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     installed: isMetaMaskInjected ? isMetaMaskInjected : undefined,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=io.metamask',

--- a/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
@@ -1,4 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -24,6 +25,7 @@ export const mewWallet = ({
     name: 'MEW wallet',
     iconUrl: async () => (await import('./mewWallet.svg')).default,
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     installed: !shouldUseWalletConnect ? isMEWInjected : undefined,
     downloadUrls: {
       android:

--- a/packages/rainbowkit/src/wallets/walletConnectors/nestWallet/nestWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/nestWallet/nestWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -10,6 +11,7 @@ export const nestWallet = (): Wallet => ({
   rdns: 'xyz.nestwallet',
   iconUrl: async () => (await import('./nestWallet.svg')).default,
   iconBackground: '#fff0',
+  chainGroup: ethereumChainGroup,
   installed: hasInjectedProvider({ flag: 'isNestWallet' }),
   downloadUrls: {
     browserExtension: 'https://nestwallet.xyz',

--- a/packages/rainbowkit/src/wallets/walletConnectors/oktoWallet/oktoWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oktoWallet/oktoWallet.ts
@@ -1,4 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -12,6 +13,7 @@ export const oktoWallet = ({
   name: 'Okto',
   iconUrl: async () => (await import('./oktoWallet.svg')).default,
   iconBackground: '#fff',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     android:
       'https://play.google.com/store/apps/details?id=im.okto.contractwalletclient',

--- a/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
@@ -1,4 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -22,6 +23,7 @@ export const okxWallet = ({
     iconUrl: async () => (await import('./okxWallet.svg')).default,
     iconAccent: '#000',
     iconBackground: '#000',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.okinc.okex.gp',

--- a/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
@@ -1,4 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -12,6 +13,7 @@ export const omniWallet = ({
   name: 'Omni',
   iconUrl: async () => (await import('./omniWallet.svg')).default,
   iconBackground: '#000',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     android: 'https://play.google.com/store/apps/details?id=fi.steakwallet.app',
     ios: 'https://itunes.apple.com/us/app/id1569375204',

--- a/packages/rainbowkit/src/wallets/walletConnectors/oneInchWallet/oneInchWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oneInchWallet/oneInchWallet.ts
@@ -1,4 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export type OneInchWalletOptions = DefaultWalletOptions;
@@ -11,6 +12,7 @@ export const oneInchWallet = ({
   name: '1inch Wallet',
   iconUrl: async () => (await import('./oneInchWallet.svg')).default,
   iconBackground: '#fff',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     android: 'https://play.google.com/store/apps/details?id=io.oneinch.android',
     ios: 'https://apps.apple.com/us/app/1inch-crypto-defi-wallet/id1546049391',

--- a/packages/rainbowkit/src/wallets/walletConnectors/oneKeyWallet/oneKeyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oneKeyWallet/oneKeyWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -11,6 +12,7 @@ export const oneKeyWallet = (): Wallet => {
     rdns: 'so.onekey.app.wallet',
     iconAccent: '#00B812',
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     iconUrl: async () => (await import('./oneKeyWallet.svg')).default,
     installed: hasInjectedProvider({ namespace: '$onekey.ethereum' }),
     downloadUrls: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/paraSwapWallet/paraswapWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/paraSwapWallet/paraswapWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -12,6 +13,7 @@ export const paraSwapWallet = ({
   name: 'ParaSwap Wallet',
   iconUrl: async () => (await import('./paraSwapWallet.svg')).default,
   iconBackground: '#578CFC',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/us/app/paraswap-multichain-wallet/id1584610690',
     mobile: 'https://paraswap.io',

--- a/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -11,6 +12,7 @@ export const phantomWallet = (): Wallet => {
     rdns: 'app.phantom',
     iconUrl: async () => (await import('./phantomWallet.svg')).default,
     iconBackground: '#9A8AEE',
+    chainGroup: ethereumChainGroup,
     installed: hasInjectedProvider({ namespace: 'phantom.ethereum' }),
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=app.phantom',

--- a/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -10,6 +11,7 @@ export const rabbyWallet = (): Wallet => ({
   iconUrl: async () => (await import('./rabbyWallet.svg')).default,
   rdns: 'io.rabby',
   iconBackground: '#8697FF',
+  chainGroup: ethereumChainGroup,
   installed: hasInjectedProvider({ flag: 'isRabby' }),
   downloadUrls: {
     chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -1,4 +1,5 @@
 import { isAndroid, isIOS } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -31,6 +32,7 @@ export const rainbowWallet = ({
     rdns: 'me.rainbow',
     iconUrl: async () => (await import('./rainbowWallet.svg')).default,
     iconBackground: '#0c2f78',
+    chainGroup: ethereumChainGroup,
     installed: !shouldUseWalletConnect ? isRainbowInjected : undefined,
     downloadUrls: {
       android:

--- a/packages/rainbowkit/src/wallets/walletConnectors/ramperWallet/ramperWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ramperWallet/ramperWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -16,6 +17,7 @@ export const ramperWallet = (): Wallet => {
     installed: isRamperWalletInjected,
     iconAccent: '#CDA349',
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/ramper-wallet/nbdhibgjnjpnkajaghbffjbkcgljfgdi',

--- a/packages/rainbowkit/src/wallets/walletConnectors/roninWallet/roninWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/roninWallet/roninWallet.ts
@@ -1,4 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -26,6 +27,7 @@ export const roninWallet = ({
     name: 'Ronin Wallet',
     iconUrl: async () => (await import('./roninWallet.svg')).default,
     iconBackground: '#ffffff',
+    chainGroup: ethereumChainGroup,
     rdns: 'com.roninchain.wallet',
     installed: isRoninInjected || undefined,
     downloadUrls: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
@@ -1,4 +1,5 @@
 import { createConnector } from 'wagmi';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { safe } from 'wagmi/connectors';
 import type { Wallet, WalletDetailsParams } from '../../Wallet';
 
@@ -7,6 +8,7 @@ export const safeWallet = (): Wallet => ({
   name: 'Safe',
   iconAccent: '#12ff80',
   iconBackground: '#fff',
+  chainGroup: ethereumChainGroup,
   iconUrl: async () => (await import('./safeWallet.svg')).default,
   installed:
     // Only allowed in iframe context

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -13,6 +14,7 @@ export const safeheronWallet = (): Wallet => ({
   }),
   iconUrl: async () => (await import('./safeheronWallet.svg')).default,
   iconBackground: '#fff',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     chrome:
       'https://chrome.google.com/webstore/detail/safeheron/aiaghdjafpiofpainifbgfgjfpclngoh',

--- a/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type {
   DefaultWalletOptions,
   InstructionStepName,
@@ -94,6 +95,7 @@ export const safepalWallet = ({
     installed: isSafePalWalletInjected,
     iconAccent: '#3375BB',
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=io.safepal.wallet&referrer=utm_source%3Drainbowkit%26utm_medium%3Ddisplay%26utm_campaign%3Ddownload',

--- a/packages/rainbowkit/src/wallets/walletConnectors/seifWallet/seifWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/seifWallet/seifWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -14,6 +15,7 @@ export function seifWallet(): Wallet {
     installed: !!injectedProvider,
     iconUrl: async () => (await import('./seifWallet.svg')).default,
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/seif/albakdmmdafeafbehmcpoejenbeojejl',

--- a/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
@@ -1,3 +1,4 @@
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type {
   DefaultWalletOptions,
   InstructionStepName,
@@ -93,6 +94,7 @@ export const subWallet = ({
     rdns: 'app.subwallet',
     iconUrl: async () => (await import('./subWallet.svg')).default,
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     installed: isSubWalletInjected || undefined,
     downloadUrls: {
       browserExtension: 'https://www.subwallet.app/download',

--- a/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -9,6 +10,7 @@ export const tahoWallet = (): Wallet => {
     id: 'taho',
     name: 'Taho',
     iconBackground: '#d08d57',
+    chainGroup: ethereumChainGroup,
     iconUrl: async () => (await import('./tahoWallet.svg')).default,
     downloadUrls: {
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -10,6 +11,7 @@ export const talismanWallet = (): Wallet => ({
   rdns: 'xyz.talisman',
   iconUrl: async () => (await import('./talismanWallet.svg')).default,
   iconBackground: '#fff',
+  chainGroup: ethereumChainGroup,
   installed: hasInjectedProvider({
     namespace: 'talismanEth',
     flag: 'isTalisman',

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
@@ -1,4 +1,5 @@
 import { isMobile } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -25,6 +26,7 @@ export const tokenPocketWallet = ({
     rdns: 'pro.tokenpocket',
     iconUrl: async () => (await import('./tokenPocketWallet.svg')).default,
     iconBackground: '#2980FE',
+    chainGroup: ethereumChainGroup,
     installed: !shouldUseWalletConnect ? isTokenPocketInjected : undefined,
     downloadUrls: {
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
@@ -1,4 +1,5 @@
 import { isSafari } from '../../../utils/browsers';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -10,6 +11,7 @@ export const tokenaryWallet = (): Wallet => ({
   name: 'Tokenary',
   iconUrl: async () => (await import('./tokenaryWallet.svg')).default,
   iconBackground: '#ffffff',
+  chainGroup: ethereumChainGroup,
   installed: hasInjectedProvider({ flag: 'isTokenary' }),
   hidden: () => !isSafari(),
   downloadUrls: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -1,4 +1,5 @@
 import { isMobile } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type {
   DefaultWalletOptions,
   InstructionStepName,
@@ -95,6 +96,7 @@ export const trustWallet = ({
     installed: isTrustWalletInjected || undefined,
     iconAccent: '#3375BB',
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.wallet.crypto.trustapp',

--- a/packages/rainbowkit/src/wallets/walletConnectors/uniswapWallet/uniswapWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/uniswapWallet/uniswapWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { DefaultWalletOptions } from './../../Wallet';
 
@@ -12,6 +13,7 @@ export const uniswapWallet = ({
   name: 'Uniswap Wallet',
   iconUrl: async () => (await import('./uniswapWallet.svg')).default,
   iconBackground: '#FFD8EA',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/app/apple-store/id6443944476',
     mobile: 'https://wallet.uniswap.org/',

--- a/packages/rainbowkit/src/wallets/walletConnectors/valoraWallet/valoraWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/valoraWallet/valoraWallet.ts
@@ -1,4 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -12,6 +13,7 @@ export const valoraWallet = ({
   name: 'Valora',
   iconUrl: async () => (await import('./valoraWallet.svg')).default,
   iconBackground: '#FFFFFF',
+  chainGroup: ethereumChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/app/id1520414263?mt=8',
     android: 'https://play.google.com/store/apps/details?id=co.clabs.valora',

--- a/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
@@ -1,4 +1,5 @@
 import type { RainbowKitWalletConnectParameters, Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface WalletConnectWalletOptions {
@@ -18,6 +19,7 @@ export const walletConnectWallet = ({
     installed: undefined,
     iconUrl: async () => (await import('./walletConnectWallet.svg')).default,
     iconBackground: '#3b99fc',
+    chainGroup: ethereumChainGroup,
     qrCode: { getUri },
     createConnector: getWalletConnectConnector({
       projectId,

--- a/packages/rainbowkit/src/wallets/walletConnectors/wigwamWallet/wigwamWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/wigwamWallet/wigwamWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -10,6 +11,7 @@ export const wigwamWallet = (): Wallet => {
     name: 'Wigwam',
     rdns: 'com.wigwam.wallet',
     iconBackground: '#80EF6E',
+    chainGroup: ethereumChainGroup,
     iconUrl: async () => (await import('./wigwamWallet.svg')).default,
     downloadUrls: {
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/xPortalWallet/xPortalWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/xPortalWallet/xPortalWallet.ts
@@ -1,4 +1,5 @@
 import { isIOS } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -29,6 +30,7 @@ export const xPortalWallet = ({
     iconUrl: async () => (await import('./xPortalWallet.svg')).default,
     iconAccent: '#23f7dd',
     iconBackground: '#23f7dd',
+    chainGroup: ethereumChainGroup,
     installed: !shouldUseWalletConnect ? isXPortalInjected : undefined,
     downloadUrls: {
       android:

--- a/packages/rainbowkit/src/wallets/walletConnectors/xdefiWallet/xdefiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/xdefiWallet/xdefiWallet.ts
@@ -1,4 +1,5 @@
 import type { Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -12,6 +13,7 @@ export const xdefiWallet = (): Wallet => {
     installed: hasInjectedProvider({ namespace: 'xfi.ethereum' }),
     iconUrl: async () => (await import('./xdefiWallet.svg')).default,
     iconBackground: '#fff',
+    chainGroup: ethereumChainGroup,
     downloadUrls: {
       chrome:
         'https://chrome.google.com/webstore/detail/xdefi-wallet/hmeobnfnfcmdkdcmlblgagmfpfboieaf',

--- a/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
@@ -1,4 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -21,6 +22,7 @@ export const zealWallet = ({
     rdns: 'app.zeal',
     iconUrl: async () => (await import('./zealWallet.svg')).default,
     iconBackground: '#fff0',
+    chainGroup: ethereumChainGroup,
     iconAccent: '#00FFFF',
     downloadUrls: {
       browserExtension: 'https://zeal.app',

--- a/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
@@ -1,4 +1,5 @@
 import { isIOS } from '../../../utils/isMobile';
+import { ethereumChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -30,6 +31,7 @@ export const zerionWallet = ({
     iconUrl: async () => (await import('./zerionWallet.svg')).default,
     iconAccent: '#2962ef',
     iconBackground: '#2962ef',
+    chainGroup: ethereumChainGroup,
     installed: !shouldUseWalletConnect ? isZerionInjected : undefined,
     downloadUrls: {
       android:


### PR DESCRIPTION
This pull request introduces a new "chain group" selection feature to RainbowKit, enhancing both desktop and mobile wallet connection flows. Users can now select a chain group (such as Ethereum) before choosing a wallet, which enables better organization and future extensibility for multi-chain support. The update includes UI changes, new types, and logic to support chain groups, and applies these changes to all wallet connectors.

### Chain Group Selection Feature

* Added chain group selection step to both desktop (`DesktopOptions.tsx`) and mobile (`MobileOptions.tsx`) wallet connection flows, allowing users to choose a chain group before picking a wallet. UI elements and state logic have been updated accordingly. [[1]](diffhunk://#diff-962bfe751c138c6e79b53b44e5fb7e4fea524534a02442c45b581fb7f17abe34L91-R115) [[2]](diffhunk://#diff-962bfe751c138c6e79b53b44e5fb7e4fea524534a02442c45b581fb7f17abe34R235-R241) [[3]](diffhunk://#diff-962bfe751c138c6e79b53b44e5fb7e4fea524534a02442c45b581fb7f17abe34R258-R275) [[4]](diffhunk://#diff-962bfe751c138c6e79b53b44e5fb7e4fea524534a02442c45b581fb7f17abe34R407-R474) [[5]](diffhunk://#diff-962bfe751c138c6e79b53b44e5fb7e4fea524534a02442c45b581fb7f17abe34L405-R489) [[6]](diffhunk://#diff-962bfe751c138c6e79b53b44e5fb7e4fea524534a02442c45b581fb7f17abe34L415-R512) [[7]](diffhunk://#diff-962bfe751c138c6e79b53b44e5fb7e4fea524534a02442c45b581fb7f17abe34L451-R557) [[8]](diffhunk://#diff-962bfe751c138c6e79b53b44e5fb7e4fea524534a02442c45b581fb7f17abe34L509-R612) [[9]](diffhunk://#diff-b590a627d2939a090b4d30f71968634350a77c20977fb16f48e478218d8292b4R27-R30) [[10]](diffhunk://#diff-b590a627d2939a090b4d30f71968634350a77c20977fb16f48e478218d8292b4R210) [[11]](diffhunk://#diff-b590a627d2939a090b4d30f71968634350a77c20977fb16f48e478218d8292b4R222-R287) [[12]](diffhunk://#diff-b590a627d2939a090b4d30f71968634350a77c20977fb16f48e478218d8292b4L244-R298) [[13]](diffhunk://#diff-b590a627d2939a090b4d30f71968634350a77c20977fb16f48e478218d8292b4L317-R371)

### Type and Utility Additions

* Introduced the `ChainGroup` type and the default `ethereumChainGroup` object, and updated wallet types to include a `chainGroup` property for each wallet. [[1]](diffhunk://#diff-b0f96b3d00217a7c644322978cd83aa23f728b35b432460abf5c8c7b0fcb52a6R78) [[2]](diffhunk://#diff-b0f96b3d00217a7c644322978cd83aa23f728b35b432460abf5c8c7b0fcb52a6R117-R125) [[3]](diffhunk://#diff-76005450891447bcacfe83dc632c08ffd8f7912feb48ea6d31ae9976b55ee066R1-R7)
* Exported the new `ChainGroup` type from the package entry point for external use.

### Wallet Connector Updates

* Updated all wallet connector definitions (e.g., ZilPay, Argent, Backpack) to specify their `chainGroup` as `ethereumChainGroup`. [[1]](diffhunk://#diff-1e2c945b0493e0d5febd999090e81f6ee9c1b1ed1e5d807e46659fa4afe031daR2) [[2]](diffhunk://#diff-1e2c945b0493e0d5febd999090e81f6ee9c1b1ed1e5d807e46659fa4afe031daR24) [[3]](diffhunk://#diff-f024e662f38823b430d717c8d4835406422e5cf0350a968797976e622f6dfc8dR1) [[4]](diffhunk://#diff-f024e662f38823b430d717c8d4835406422e5cf0350a968797976e622f6dfc8dR30) [[5]](diffhunk://#diff-66baedd6716166a7328f69be187f7818ab9f7a91e383c1cbe2890562f7464316R1) [[6]](diffhunk://#diff-66baedd6716166a7328f69be187f7818ab9f7a91e383c1cbe2890562f7464316R16)

### Localization and UI Improvements

* Added new i18n strings for chain group selection in English locale files, ensuring proper labeling and instructions for the new feature. [[1]](diffhunk://#diff-21500eaed37d399caf88a4c749710497b120c8b23e1d4ea88f90ea724b351fd1R49-R51) [[2]](diffhunk://#diff-21500eaed37d399caf88a4c749710497b120c8b23e1d4ea88f90ea724b351fd1R200-R201)

### Version Bump

* Bumped the package version to `2.2.7` to reflect these new features and improvements.