### PR TITLE
fix: chain group picker

### DIFF
--- a/packages/rainbowkit/package.json
+++ b/packages/rainbowkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stakekit/rainbowkit",
-  "version": "2.2.7",
+  "version": "2.2.9",
   "description": "The best way to connect a wallet",
   "files": ["dist", "styles.css", "wallets"],
   "type": "module",

--- a/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/DesktopOptions.tsx
@@ -98,7 +98,7 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
 
   const [selectedChainGroupId, setSelectedChainGroupId] = useState<
     ChainGroup['id'] | undefined
-  >(Object.values(chainGroups).length > 1 ? undefined : 'ethereum');
+  >(Object.values(chainGroups).length > 1 ? undefined : 'evm');
 
   const groupedByChainGroupWallets = groupBy(
     wallets,
@@ -230,6 +230,11 @@ export function DesktopOptions({ onClose }: { onClose: () => void }) {
     } else if (!isBack && newWalletStep === WalletStep.Connect) {
       setInitialWalletStep(WalletStep.Connect);
     }
+
+    if (newWalletStep === WalletStep.SelectChainGroup && selectedChainGroupId) {
+      setSelectedChainGroupId(undefined);
+    }
+
     setWalletStep(newWalletStep);
   };
 

--- a/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
+++ b/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx
@@ -226,7 +226,7 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
 
   const [selectedChainGroupId, setSelectedChainGroupId] = useState<
     ChainGroup['id'] | undefined
-  >(Object.values(chainGroups).length > 1 ? undefined : 'ethereum');
+  >(Object.values(chainGroups).length > 1 ? undefined : 'evm');
 
   const groupedByChainGroupWallets = groupBy(
     wallets,
@@ -248,13 +248,31 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
       : MobileWalletStep.Connect,
   );
 
+  const changeWalletStep = (newWalletStep: MobileWalletStep) => {
+    if (
+      newWalletStep === MobileWalletStep.SelectChainGroup &&
+      selectedChainGroupId
+    ) {
+      setSelectedChainGroupId(undefined);
+    }
+
+    setWalletStep(newWalletStep);
+  };
+
+  if (
+    walletStep === MobileWalletStep.SelectChainGroup &&
+    selectedChainGroupId
+  ) {
+    setSelectedChainGroupId(undefined);
+  }
+
   const { i18n } = useContext(I18nContext);
 
   const ios = isIOS();
 
   const onChainGroupSelect = (chainGroupId: string) => {
     setSelectedChainGroupId(chainGroupId);
-    setWalletStep(MobileWalletStep.Connect);
+    changeWalletStep(MobileWalletStep.Connect);
   };
 
   switch (walletStep) {
@@ -343,7 +361,7 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
             <Box display="flex" gap="14" justifyContent="center">
               <ActionButton
                 label={i18n.t('intro.get.label')}
-                onClick={() => setWalletStep(MobileWalletStep.Get)}
+                onClick={() => changeWalletStep(MobileWalletStep.Get)}
                 size="large"
                 type="secondary"
               />
@@ -518,7 +536,7 @@ export function MobileOptions({ onClose }: { onClose: () => void }) {
                 display="flex"
                 marginLeft="4"
                 marginTop="20"
-                onClick={() => setWalletStep(headerBackButtonLink!)}
+                onClick={() => changeWalletStep(headerBackButtonLink!)}
                 padding="16"
                 style={{ height: 17, willChange: 'transform' }}
                 transition="default"

--- a/packages/rainbowkit/src/utils/chain-groups.ts
+++ b/packages/rainbowkit/src/utils/chain-groups.ts
@@ -1,7 +1,7 @@
 import type { ChainGroup } from '../wallets/Wallet';
 
-export const ethereumChainGroup: ChainGroup = {
-  id: 'ethereum',
-  title: 'Ethereum',
+export const evmChainGroup: ChainGroup = {
+  id: 'evm',
+  title: 'EVM',
   iconUrl: 'https://assets.stakek.it/networks/ethereum.svg',
 };

--- a/packages/rainbowkit/src/wallets/Wallet.ts
+++ b/packages/rainbowkit/src/wallets/Wallet.ts
@@ -118,7 +118,7 @@ export type RainbowKitDetails = Omit<Wallet, 'createConnector' | 'hidden'> & {
 };
 
 export interface ChainGroup {
-  id: 'ethereum' | (string & {});
+  id: 'evm' | (string & {});
   title: string;
   iconUrl: string;
 }

--- a/packages/rainbowkit/src/wallets/walletConnectors/ZilPayWallet/zilPayWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ZilPayWallet/zilPayWallet.ts
@@ -1,5 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -21,7 +21,7 @@ export const zilPayWallet = ({
     rdns: 'io.zilpay',
     iconUrl: async () => (await import('./zilPayWallet.svg')).default,
     iconBackground: '#ffffff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=com.zilpaymobile',
       ios: 'https://apps.apple.com/ru/app/zilpay/id1547105860',

--- a/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
@@ -27,7 +27,7 @@ export const argentWallet = ({
         : `argent://app/wc?uri=${encodeURIComponent(uri)}`;
     },
   },
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   qrCode: {
     getUri: (uri: string) => uri,
     instructions: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/backpackWallet/backpackWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/backpackWallet/backpackWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -13,7 +13,7 @@ export const backpackWallet = (): Wallet => {
     iconUrl: async () => (await import('./backpackWallet.svg')).default,
     iconBackground: '#0C0D10',
     installed: hasInjectedProvider({ namespace: 'backpack.ethereum' }),
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=app.backpack.mobile',

--- a/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/berasigWallet/berasigWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -24,7 +24,7 @@ export const berasigWallet = ({
     iconUrl: async () => (await import('./berasigWallet.svg')).default,
     iconBackground: '#ffffff',
     installed: isBerasigWalletInjected,
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=io.berasig.ios',
       ios: 'https://apps.apple.com/us/app/berasig-wallet-on-berachain/id6502052535',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bestWallet/bestWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bestWallet/bestWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { DefaultWalletOptions } from './../../Wallet';
@@ -13,7 +13,7 @@ export const bestWallet = ({
   name: 'Best Wallet',
   iconUrl: async () => (await import('./bestWallet.svg')).default,
   iconBackground: '#5961FF',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     android: 'https://best.sng.link/Dnio2/rto7?_smtype=3',
     ios: 'https://best.sng.link/Dnio2/rto7?_smtype=3',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bifrostWallet/bifrostWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { Wallet } from '../../Wallet';
 import {
@@ -31,7 +31,7 @@ export const bifrostWallet = ({
     iconUrl: async () => (await import('./bifrostWallet.svg')).default,
     iconBackground: '#fff',
     installed: !shouldUseWalletConnect ? isBifrostInjected : undefined,
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.bifrostwallet.app',

--- a/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/binanceWallet/binanceWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
@@ -25,7 +25,7 @@ export const binanceWallet = ({
     iconUrl: async () => (await import('./binanceWallet.svg')).default,
     iconBackground: '#000000',
     installed: !shouldUseWalletConnect ? isBinanceInjected : undefined,
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=com.binance.dev',
       ios: 'https://apps.apple.com/us/app/id1436799971',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitgetWallet/bitgetWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
@@ -27,7 +27,7 @@ export const bitgetWallet = ({
     iconAccent: '#f6851a',
     iconBackground: '#fff',
     installed: !shouldUseWalletConnect ? isBitKeepInjected : undefined,
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android: 'https://web3.bitget.com/en/wallet-download?type=0',
       ios: 'https://apps.apple.com/app/bitkeep/id1395301115',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitskiWallet/bitskiWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -11,7 +11,7 @@ export const bitskiWallet = (): Wallet => ({
   installed: hasInjectedProvider({ flag: 'isBitski' }),
   iconUrl: async () => (await import('./bitskiWallet.svg')).default,
   iconBackground: '#fff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     chrome:
       'https://chrome.google.com/webstore/detail/bitski/feejiigddaafeojfddjjlmfkabimkell',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bitverseWallet/bitverseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bitverseWallet/bitverseWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -12,7 +12,7 @@ export const bitverseWallet = ({
   name: 'Bitverse Wallet',
   iconUrl: async () => (await import('./bitverseWallet.svg')).default,
   iconBackground: '#171728',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     android:
       'https://play.google.com/store/apps/details?id=com.bitverse.app&pli=1',

--- a/packages/rainbowkit/src/wallets/walletConnectors/bloomWallet/bloomWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bloomWallet/bloomWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -11,7 +11,7 @@ export const bloomWallet = ({
   iconBackground: '#000',
   iconAccent: '#000',
   iconUrl: async () => (await import('./bloomWallet.svg')).default,
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     desktop: 'https://bloomwallet.io/',
   },

--- a/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/braveWallet/braveWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -12,7 +12,7 @@ export const braveWallet = (): Wallet => ({
   iconUrl: async () => (await import('./braveWallet.svg')).default,
   iconBackground: '#fff',
   installed: hasInjectedProvider({ flag: 'isBraveWallet' }),
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     // We're opting not to provide a download prompt if Brave isn't the current
     // browser since it's unlikely to be a desired behavior for users. It's

--- a/packages/rainbowkit/src/wallets/walletConnectors/bybitWallet/bybitWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/bybitWallet/bybitWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -31,7 +31,7 @@ export const bybitWallet = ({
     iconUrl: async () => (await import('./bybitWallet.svg')).default,
     installed: !shouldUseWalletConnect ? isBybitInjected : undefined,
     iconBackground: '#000000',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/bybit-wallet/pdliaogehgdbhbnmkklieghmmjkpigpa',

--- a/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/clvWallet/clvWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -22,7 +22,7 @@ export const clvWallet = ({
     iconBackground: '#fff',
     iconAccent: '#BDFDE2',
     installed: isCLVInjected,
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       chrome:
         'https://chrome.google.com/webstore/detail/clv-wallet/nhnkbkgjikgcigadomkphalanndcapjk',

--- a/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coin98Wallet/coin98Wallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -26,7 +26,7 @@ export const coin98Wallet = ({
     iconAccent: '#CDA349',
     iconBackground: '#fff',
     rdns: 'coin98.com',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=coin98.crypto.finance.media',

--- a/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coinbaseWallet/coinbaseWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { type CreateConnectorFn, createConnector } from 'wagmi';
 import {
   type CoinbaseWalletParameters,
@@ -38,7 +38,7 @@ export const coinbaseWallet: CoinbaseWallet = ({ appName, appIcon }) => {
     // prompting the user to connect or create a wallet via passkey. This means if you either have
     // or don't have the coinbase wallet browser extension installed it'll do some action anyways
     installed: true,
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=org.toshi',
       ios: 'https://apps.apple.com/us/app/coinbase-wallet-store-crypto/id1278383455',

--- a/packages/rainbowkit/src/wallets/walletConnectors/compassWallet/compassWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/compassWallet/compassWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -15,7 +15,7 @@ export const compassWallet = (): Wallet => {
     rdns: 'io.leapwallet.CompassWallet',
     iconUrl: async () => (await import('./compassWallet.svg')).default,
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/compass-wallet-for-sei/anokgmphncpekkhclmingpimjmcooifb',

--- a/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/coreWallet/coreWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -24,7 +24,7 @@ export const coreWallet = ({
     iconUrl: async () => (await import('./coreWallet.svg')).default,
     iconBackground: '#1A1A1C',
     installed: !shouldUseWalletConnect ? isCoreInjected : undefined,
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=com.avaxwallet',
       ios: 'https://apps.apple.com/us/app/core-wallet/id6443685999',

--- a/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/dawnWallet/dawnWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { isIOS } from '../../../utils/isMobile';
 import type { Wallet } from '../../Wallet';
 import {
@@ -13,7 +13,7 @@ export const dawnWallet = (): Wallet => ({
   iconBackground: '#000000',
   installed: hasInjectedProvider({ flag: 'isDawn' }),
   hidden: () => !isIOS(),
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/us/app/dawn-ethereum-wallet/id1673143782',
     mobile: 'https://dawnwallet.xyz',

--- a/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/desigWallet/desigWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -12,7 +12,7 @@ export const desigWallet = (): Wallet => {
     iconUrl: async () => (await import('./desigWallet.svg')).default,
     iconBackground: '#ffffff',
     installed: hasInjectedProvider({ namespace: 'desig.ethereum' }),
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=io.desig.app',
       ios: 'https://apps.apple.com/app/desig-wallet/id6450106028',

--- a/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/enkryptWallet/enkryptWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -13,7 +13,7 @@ export const enkryptWallet = (): Wallet => {
     installed: hasInjectedProvider({ namespace: 'enkrypt.providers.ethereum' }),
     iconUrl: async () => (await import('./enkryptWallet.svg')).default,
     iconBackground: '#FFFFFF',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       qrCode: 'https://www.enkrypt.com',
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/foxWallet/foxWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -22,7 +22,7 @@ export const foxWallet = ({
     name: 'FoxWallet',
     iconUrl: async () => (await import('./foxWallet.svg')).default,
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.foxwallet.play',

--- a/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frameWallet/frameWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -12,7 +12,7 @@ export const frameWallet = (): Wallet => ({
   installed: hasInjectedProvider({ flag: 'isFrame' }),
   iconUrl: async () => (await import('./frameWallet.svg')).default,
   iconBackground: '#121C20',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     browserExtension: 'https://frame.sh/',
   },

--- a/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/frontierWallet/frontierWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { Wallet } from '../../Wallet';
 import {
@@ -26,7 +26,7 @@ export const frontierWallet = ({
     installed: isFrontierInjected,
     iconUrl: async () => (await import('./frontierWallet.svg')).default,
     iconBackground: '#CC703C',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.frontierwallet',

--- a/packages/rainbowkit/src/wallets/walletConnectors/gateWallet/gateWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/gateWallet/gateWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
@@ -23,7 +23,7 @@ export const gateWallet = ({
     iconUrl: async () => (await import('./gateWallet.svg')).default,
     iconAccent: '#fff',
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.gateio.gateio',

--- a/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/imTokenWallet/imTokenWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -12,7 +12,7 @@ export const imTokenWallet = ({
   name: 'imToken',
   iconUrl: async () => (await import('./imTokenWallet.svg')).default,
   iconBackground: '#098de6',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     android: 'https://play.google.com/store/apps/details?id=im.token.app',
     ios: 'https://itunes.apple.com/us/app/imtoken2/id1384798940',

--- a/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import { getInjectedConnector } from '../../getInjectedConnector';
 
@@ -7,6 +7,6 @@ export const injectedWallet = (): Wallet => ({
   name: 'Browser Wallet',
   iconUrl: async () => (await import('./injectedWallet.svg')).default,
   iconBackground: '#fff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   createConnector: getInjectedConnector({}),
 });

--- a/packages/rainbowkit/src/wallets/walletConnectors/iopayWallet/iopayWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/iopayWallet/iopayWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { isAndroid } from '../../../utils/isMobile';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getInjectedConnector } from '../../getInjectedConnector';
@@ -23,7 +23,7 @@ export const iopayWallet = ({
   name: 'ioPay Wallet',
   iconUrl: async () => (await import('./iopayWallet.svg')).default,
   iconBackground: '#fff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     android:
       'https://play.google.com/store/apps/details?id=io.iotex.iopay.gp&pli=1',

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaiaWallet/kaiaWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaiaWallet/kaiaWallet.ts
@@ -1,5 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -28,7 +28,7 @@ export const kaiaWallet = ({
     iconUrl: async () => (await import('./kaiaWallet.svg')).default,
     installed: isKaiaWalletInjected || undefined,
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/kaia-wallet/jblndlipeogpafnldhgmapagcccfchpi',

--- a/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kaikasWallet/kaikasWallet.ts
@@ -1,5 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -28,7 +28,7 @@ export const kaikasWallet = ({
     iconUrl: async () => (await import('./kaikasWallet.svg')).default,
     installed: isKaikasWalletInjected || undefined,
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/kaikas/jblndlipeogpafnldhgmapagcccfchpi',

--- a/packages/rainbowkit/src/wallets/walletConnectors/krakenWallet/krakenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/krakenWallet/krakenWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { DefaultWalletOptions } from './../../Wallet';
 
@@ -13,7 +13,7 @@ export const krakenWallet = ({
   name: 'Kraken Wallet',
   iconUrl: async () => (await import('./krakenWallet.svg')).default,
   iconBackground: '#FFD8EA',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/us/app/kraken-wallet/id1626327149',
     mobile: 'https://kraken.com/wallet',

--- a/packages/rainbowkit/src/wallets/walletConnectors/kresusWallet/kresusWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/kresusWallet/kresusWallet.ts
@@ -1,5 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export type KresusWalletOptions = DefaultWalletOptions;
@@ -12,7 +12,7 @@ export const kresusWallet = ({
   name: 'Kresus Wallet',
   iconUrl: async () => (await import('./kresusWallet.svg')).default,
   iconBackground: '#fff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     android:
       'https://play.google.com/store/apps/details?id=com.kresus.superapp',

--- a/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ledgerWallet/ledgerWallet.ts
@@ -1,5 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -11,7 +11,7 @@ export const ledgerWallet = ({
 }: LedgerWalletOptions): Wallet => ({
   id: 'ledger',
   iconBackground: '#000',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   iconAccent: '#000',
   name: 'Ledger',
   iconUrl: async () => (await import('./ledgerWallet.svg')).default,

--- a/packages/rainbowkit/src/wallets/walletConnectors/magicEdenWallet/magicEdenWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/magicEdenWallet/magicEdenWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -12,7 +12,7 @@ export const magicEdenWallet = (): Wallet => {
     rdns: 'io.magiceden.wallet',
     iconUrl: async () => (await import('./magicEden.svg')).default,
     iconBackground: '#36114D',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     installed: hasInjectedProvider({ namespace: 'magicEden.ethereum' }),
     downloadUrls: {
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/metaMaskWallet/metaMaskWallet.ts
@@ -1,5 +1,5 @@
 import { createConnector } from 'wagmi';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { metaMask } from 'wagmi/connectors';
 import type {
   DefaultWalletOptions,
@@ -83,7 +83,7 @@ export const metaMaskWallet = ({
     iconUrl: async () => (await import('./metaMaskWallet.svg')).default,
     iconAccent: '#f6851a',
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     installed: isMetaMaskInjected ? isMetaMaskInjected : undefined,
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=io.metamask',

--- a/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/mewWallet/mewWallet.ts
@@ -1,5 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -25,7 +25,7 @@ export const mewWallet = ({
     name: 'MEW wallet',
     iconUrl: async () => (await import('./mewWallet.svg')).default,
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     installed: !shouldUseWalletConnect ? isMEWInjected : undefined,
     downloadUrls: {
       android:

--- a/packages/rainbowkit/src/wallets/walletConnectors/nestWallet/nestWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/nestWallet/nestWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -11,7 +11,7 @@ export const nestWallet = (): Wallet => ({
   rdns: 'xyz.nestwallet',
   iconUrl: async () => (await import('./nestWallet.svg')).default,
   iconBackground: '#fff0',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   installed: hasInjectedProvider({ flag: 'isNestWallet' }),
   downloadUrls: {
     browserExtension: 'https://nestwallet.xyz',

--- a/packages/rainbowkit/src/wallets/walletConnectors/oktoWallet/oktoWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oktoWallet/oktoWallet.ts
@@ -1,5 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -13,7 +13,7 @@ export const oktoWallet = ({
   name: 'Okto',
   iconUrl: async () => (await import('./oktoWallet.svg')).default,
   iconBackground: '#fff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     android:
       'https://play.google.com/store/apps/details?id=im.okto.contractwalletclient',

--- a/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/okxWallet/okxWallet.ts
@@ -1,5 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -23,7 +23,7 @@ export const okxWallet = ({
     iconUrl: async () => (await import('./okxWallet.svg')).default,
     iconAccent: '#000',
     iconBackground: '#000',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.okinc.okex.gp',

--- a/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts
@@ -1,5 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -13,7 +13,7 @@ export const omniWallet = ({
   name: 'Omni',
   iconUrl: async () => (await import('./omniWallet.svg')).default,
   iconBackground: '#000',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     android: 'https://play.google.com/store/apps/details?id=fi.steakwallet.app',
     ios: 'https://itunes.apple.com/us/app/id1569375204',

--- a/packages/rainbowkit/src/wallets/walletConnectors/oneInchWallet/oneInchWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oneInchWallet/oneInchWallet.ts
@@ -1,5 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export type OneInchWalletOptions = DefaultWalletOptions;
@@ -12,7 +12,7 @@ export const oneInchWallet = ({
   name: '1inch Wallet',
   iconUrl: async () => (await import('./oneInchWallet.svg')).default,
   iconBackground: '#fff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     android: 'https://play.google.com/store/apps/details?id=io.oneinch.android',
     ios: 'https://apps.apple.com/us/app/1inch-crypto-defi-wallet/id1546049391',

--- a/packages/rainbowkit/src/wallets/walletConnectors/oneKeyWallet/oneKeyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/oneKeyWallet/oneKeyWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -12,7 +12,7 @@ export const oneKeyWallet = (): Wallet => {
     rdns: 'so.onekey.app.wallet',
     iconAccent: '#00B812',
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     iconUrl: async () => (await import('./oneKeyWallet.svg')).default,
     installed: hasInjectedProvider({ namespace: '$onekey.ethereum' }),
     downloadUrls: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/paraSwapWallet/paraswapWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/paraSwapWallet/paraswapWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -13,7 +13,7 @@ export const paraSwapWallet = ({
   name: 'ParaSwap Wallet',
   iconUrl: async () => (await import('./paraSwapWallet.svg')).default,
   iconBackground: '#578CFC',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/us/app/paraswap-multichain-wallet/id1584610690',
     mobile: 'https://paraswap.io',

--- a/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/phantomWallet/phantomWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -12,7 +12,7 @@ export const phantomWallet = (): Wallet => {
     rdns: 'app.phantom',
     iconUrl: async () => (await import('./phantomWallet.svg')).default,
     iconBackground: '#9A8AEE',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     installed: hasInjectedProvider({ namespace: 'phantom.ethereum' }),
     downloadUrls: {
       android: 'https://play.google.com/store/apps/details?id=app.phantom',

--- a/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rabbyWallet/rabbyWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -11,7 +11,7 @@ export const rabbyWallet = (): Wallet => ({
   iconUrl: async () => (await import('./rabbyWallet.svg')).default,
   rdns: 'io.rabby',
   iconBackground: '#8697FF',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   installed: hasInjectedProvider({ flag: 'isRabby' }),
   downloadUrls: {
     chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/rainbowWallet/rainbowWallet.ts
@@ -1,5 +1,5 @@
 import { isAndroid, isIOS } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -32,7 +32,7 @@ export const rainbowWallet = ({
     rdns: 'me.rainbow',
     iconUrl: async () => (await import('./rainbowWallet.svg')).default,
     iconBackground: '#0c2f78',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     installed: !shouldUseWalletConnect ? isRainbowInjected : undefined,
     downloadUrls: {
       android:

--- a/packages/rainbowkit/src/wallets/walletConnectors/ramperWallet/ramperWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/ramperWallet/ramperWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -17,7 +17,7 @@ export const ramperWallet = (): Wallet => {
     installed: isRamperWalletInjected,
     iconAccent: '#CDA349',
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/ramper-wallet/nbdhibgjnjpnkajaghbffjbkcgljfgdi',

--- a/packages/rainbowkit/src/wallets/walletConnectors/roninWallet/roninWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/roninWallet/roninWallet.ts
@@ -1,5 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -27,7 +27,7 @@ export const roninWallet = ({
     name: 'Ronin Wallet',
     iconUrl: async () => (await import('./roninWallet.svg')).default,
     iconBackground: '#ffffff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     rdns: 'com.roninchain.wallet',
     installed: isRoninInjected || undefined,
     downloadUrls: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeWallet/safeWallet.ts
@@ -1,5 +1,5 @@
 import { createConnector } from 'wagmi';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { safe } from 'wagmi/connectors';
 import type { Wallet, WalletDetailsParams } from '../../Wallet';
 
@@ -8,7 +8,7 @@ export const safeWallet = (): Wallet => ({
   name: 'Safe',
   iconAccent: '#12ff80',
   iconBackground: '#fff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   iconUrl: async () => (await import('./safeWallet.svg')).default,
   installed:
     // Only allowed in iframe context

--- a/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safeheronWallet/safeheronWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -14,7 +14,7 @@ export const safeheronWallet = (): Wallet => ({
   }),
   iconUrl: async () => (await import('./safeheronWallet.svg')).default,
   iconBackground: '#fff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     chrome:
       'https://chrome.google.com/webstore/detail/safeheron/aiaghdjafpiofpainifbgfgjfpclngoh',

--- a/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/safepalWallet/safepalWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type {
   DefaultWalletOptions,
   InstructionStepName,
@@ -95,7 +95,7 @@ export const safepalWallet = ({
     installed: isSafePalWalletInjected,
     iconAccent: '#3375BB',
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=io.safepal.wallet&referrer=utm_source%3Drainbowkit%26utm_medium%3Ddisplay%26utm_campaign%3Ddownload',

--- a/packages/rainbowkit/src/wallets/walletConnectors/seifWallet/seifWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/seifWallet/seifWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -15,7 +15,7 @@ export function seifWallet(): Wallet {
     installed: !!injectedProvider,
     iconUrl: async () => (await import('./seifWallet.svg')).default,
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       chrome:
         'https://chromewebstore.google.com/detail/seif/albakdmmdafeafbehmcpoejenbeojejl',

--- a/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/subWallet/subWallet.ts
@@ -1,4 +1,4 @@
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type {
   DefaultWalletOptions,
   InstructionStepName,
@@ -94,7 +94,7 @@ export const subWallet = ({
     rdns: 'app.subwallet',
     iconUrl: async () => (await import('./subWallet.svg')).default,
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     installed: isSubWalletInjected || undefined,
     downloadUrls: {
       browserExtension: 'https://www.subwallet.app/download',

--- a/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tahoWallet/tahoWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -10,7 +10,7 @@ export const tahoWallet = (): Wallet => {
     id: 'taho',
     name: 'Taho',
     iconBackground: '#d08d57',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     iconUrl: async () => (await import('./tahoWallet.svg')).default,
     downloadUrls: {
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/talismanWallet/talismanWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -11,7 +11,7 @@ export const talismanWallet = (): Wallet => ({
   rdns: 'xyz.talisman',
   iconUrl: async () => (await import('./talismanWallet.svg')).default,
   iconBackground: '#fff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   installed: hasInjectedProvider({
     namespace: 'talismanEth',
     flag: 'isTalisman',

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenPocketWallet/tokenPocketWallet.ts
@@ -1,5 +1,5 @@
 import { isMobile } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -26,7 +26,7 @@ export const tokenPocketWallet = ({
     rdns: 'pro.tokenpocket',
     iconUrl: async () => (await import('./tokenPocketWallet.svg')).default,
     iconBackground: '#2980FE',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     installed: !shouldUseWalletConnect ? isTokenPocketInjected : undefined,
     downloadUrls: {
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/tokenaryWallet/tokenaryWallet.ts
@@ -1,5 +1,5 @@
 import { isSafari } from '../../../utils/browsers';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -11,7 +11,7 @@ export const tokenaryWallet = (): Wallet => ({
   name: 'Tokenary',
   iconUrl: async () => (await import('./tokenaryWallet.svg')).default,
   iconBackground: '#ffffff',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   installed: hasInjectedProvider({ flag: 'isTokenary' }),
   hidden: () => !isSafari(),
   downloadUrls: {

--- a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts
@@ -1,5 +1,5 @@
 import { isMobile } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type {
   DefaultWalletOptions,
   InstructionStepName,
@@ -96,7 +96,7 @@ export const trustWallet = ({
     installed: isTrustWalletInjected || undefined,
     iconAccent: '#3375BB',
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       android:
         'https://play.google.com/store/apps/details?id=com.wallet.crypto.trustapp',

--- a/packages/rainbowkit/src/wallets/walletConnectors/uniswapWallet/uniswapWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/uniswapWallet/uniswapWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 import type { DefaultWalletOptions } from './../../Wallet';
 
@@ -13,7 +13,7 @@ export const uniswapWallet = ({
   name: 'Uniswap Wallet',
   iconUrl: async () => (await import('./uniswapWallet.svg')).default,
   iconBackground: '#FFD8EA',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/app/apple-store/id6443944476',
     mobile: 'https://wallet.uniswap.org/',

--- a/packages/rainbowkit/src/wallets/walletConnectors/valoraWallet/valoraWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/valoraWallet/valoraWallet.ts
@@ -1,5 +1,5 @@
 import { isAndroid } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
@@ -13,7 +13,7 @@ export const valoraWallet = ({
   name: 'Valora',
   iconUrl: async () => (await import('./valoraWallet.svg')).default,
   iconBackground: '#FFFFFF',
-  chainGroup: ethereumChainGroup,
+  chainGroup: evmChainGroup,
   downloadUrls: {
     ios: 'https://apps.apple.com/app/id1520414263?mt=8',
     android: 'https://play.google.com/store/apps/details?id=co.clabs.valora',

--- a/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/walletConnectWallet/walletConnectWallet.ts
@@ -1,5 +1,5 @@
 import type { RainbowKitWalletConnectParameters, Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import { getWalletConnectConnector } from '../../getWalletConnectConnector';
 
 export interface WalletConnectWalletOptions {
@@ -19,7 +19,7 @@ export const walletConnectWallet = ({
     installed: undefined,
     iconUrl: async () => (await import('./walletConnectWallet.svg')).default,
     iconBackground: '#3b99fc',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     qrCode: { getUri },
     createConnector: getWalletConnectConnector({
       projectId,

--- a/packages/rainbowkit/src/wallets/walletConnectors/wigwamWallet/wigwamWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/wigwamWallet/wigwamWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -11,7 +11,7 @@ export const wigwamWallet = (): Wallet => {
     name: 'Wigwam',
     rdns: 'com.wigwam.wallet',
     iconBackground: '#80EF6E',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     iconUrl: async () => (await import('./wigwamWallet.svg')).default,
     downloadUrls: {
       chrome:

--- a/packages/rainbowkit/src/wallets/walletConnectors/xPortalWallet/xPortalWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/xPortalWallet/xPortalWallet.ts
@@ -1,5 +1,5 @@
 import { isIOS } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -30,7 +30,7 @@ export const xPortalWallet = ({
     iconUrl: async () => (await import('./xPortalWallet.svg')).default,
     iconAccent: '#23f7dd',
     iconBackground: '#23f7dd',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     installed: !shouldUseWalletConnect ? isXPortalInjected : undefined,
     downloadUrls: {
       android:

--- a/packages/rainbowkit/src/wallets/walletConnectors/xdefiWallet/xdefiWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/xdefiWallet/xdefiWallet.ts
@@ -1,5 +1,5 @@
 import type { Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -13,7 +13,7 @@ export const xdefiWallet = (): Wallet => {
     installed: hasInjectedProvider({ namespace: 'xfi.ethereum' }),
     iconUrl: async () => (await import('./xdefiWallet.svg')).default,
     iconBackground: '#fff',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     downloadUrls: {
       chrome:
         'https://chrome.google.com/webstore/detail/xdefi-wallet/hmeobnfnfcmdkdcmlblgagmfpfboieaf',

--- a/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zealWallet/zealWallet.ts
@@ -1,5 +1,5 @@
 import type { DefaultWalletOptions, Wallet } from '../../Wallet';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import {
   getInjectedConnector,
   hasInjectedProvider,
@@ -22,7 +22,7 @@ export const zealWallet = ({
     rdns: 'app.zeal',
     iconUrl: async () => (await import('./zealWallet.svg')).default,
     iconBackground: '#fff0',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     iconAccent: '#00FFFF',
     downloadUrls: {
       browserExtension: 'https://zeal.app',

--- a/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
+++ b/packages/rainbowkit/src/wallets/walletConnectors/zerionWallet/zerionWallet.ts
@@ -1,5 +1,5 @@
 import { isIOS } from '../../../utils/isMobile';
-import { ethereumChainGroup } from '../../../utils/chain-groups';
+import { evmChainGroup } from '../../../utils/chain-groups';
 import type { Wallet } from '../../Wallet';
 import {
   getInjectedConnector,
@@ -31,7 +31,7 @@ export const zerionWallet = ({
     iconUrl: async () => (await import('./zerionWallet.svg')).default,
     iconAccent: '#2962ef',
     iconBackground: '#2962ef',
-    chainGroup: ethereumChainGroup,
+    chainGroup: evmChainGroup,
     installed: !shouldUseWalletConnect ? isZerionInjected : undefined,
     downloadUrls: {
       android:


### PR DESCRIPTION
This pull request updates the `@stakekit/rainbowkit` package version and introduces a fix for wallet selection behavior in both desktop and mobile connection options. The main improvement ensures that the `selectedChainGroupId` is reset when navigating to the chain group selection step, preventing unintended state persistence.

Version update:

* Bumped the package version from `2.2.7` to `2.2.8` in `package.json` to reflect the new changes.

State management fixes:

* In `DesktopOptions.tsx`, added logic to reset `selectedChainGroupId` when the user navigates to the `SelectChainGroup` step, ensuring the correct selection state.
* In `MobileOptions.tsx`, applied the same fix for mobile by resetting `selectedChainGroupId` when the user is at the `SelectChainGroup` step.